### PR TITLE
Pull Request: Add Django-PyHat-With-Docker-and-Celery Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ A software collection implementing the Knowledge Base paradigm using the FO(.) l
 A web server and client to manage conda-forge environments from the browser and access them through JupyterLab. Uses htmx on the front-end.
 - **[Harfang](https://github.com/sqwxl/harfang)** <a href="https://docs.djangoproject.com/en/" target="_blank"><img src="https://img.shields.io/badge/-Django-a9bbcc?style=flat&logo=django&logoColor=black" alt="Django"></a><br/>
 A social content posting and discussion site with a focus on simplicity and accessibility. Inspired by Hacker News and Reddit. Built with Django, HTMX, Alpine.js and Tailwind CSS
+- **[Django-PyHat-With-Docker-and-Celery](https://github.com/Naude555/Django-PyHat-With-Docker-and-Celery)** <a href="https://docs.djangoproject.com/en/" target="_blank"><img src="https://img.shields.io/badge/-Django-a9bbcc?style=flat&logo=django&logoColor=black" alt="Django"></a><br/>
+A starter project that includes everything for a Python HTMX Alpine.js and Tailwind project that has been dockerized and includes setup for Celery and Celery Beat.
 
 ## Further Reading 📖
 


### PR DESCRIPTION
This pull request adds a new project, **Django-PyHat-With-Docker-and-Celery**, to the list of projects in the repository. The new entry includes a link to the GitHub repository and a brief description of the project.

 A starter project that includes everything for a Python HTMX Alpine.js and Tailwind project that has been dockerized and includes setup for Celery and Celery Beat.
